### PR TITLE
MinGW build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,13 @@ project(legacy-notepad LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(MSVC)
     add_compile_options(/W4 /WX /permissive- /utf-8)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS /ENTRY:wWinMainCRTStartup")
 else()
-    add_compile_options(-Wall -Wextra -Werror -municode)
+    add_compile_options(-Wall -Wextra -Werror -municode -Wno-error=missing-field-initializers)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mwindows")
 endif()
 
@@ -21,8 +22,18 @@ target_link_libraries(legacy-notepad PRIVATE
     comctl32
     shlwapi
     comdlg32
+    shell32
+    gdiplus
+    msimg32
+    user32
+    gdi32
+    kernel32
 )
 
 if(NOT MSVC)
+    target_link_options(legacy-notepad PRIVATE -mwindows -municode)
     target_link_libraries(legacy-notepad PRIVATE -static-libgcc -static-libstdc++)
+    add_custom_command(TARGET legacy-notepad POST_BUILD COMMAND ${CMAKE_STRIP} --strip-all $<TARGET_FILE:legacy-notepad>)
 endif()
+
+target_compile_definitions(legacy-notepad PRIVATE UNICODE _UNICODE)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,3 @@
-#ifndef UNICODE
-#define UNICODE
-#endif
-#ifndef _UNICODE
-#define _UNICODE
-#endif
-
 #include <windows.h>
 #include <windowsx.h>
 #include <commctrl.h>
@@ -16,13 +9,6 @@
 #include <vector>
 #include <deque>
 #include <algorithm>
-
-#pragma comment(lib, "comctl32.lib")
-#pragma comment(lib, "shlwapi.lib")
-#pragma comment(lib, "comdlg32.lib")
-#pragma comment(lib, "shell32.lib")
-#pragma comment(lib, "gdiplus.lib")
-#pragma comment(lib, "msimg32.lib")
 
 #include <gdiplus.h>
 


### PR DESCRIPTION
- Adds build support for MinGW (uses ninja)
- Fix library defines and ignores a warning (or if the actual code can be fixed, let me know)
- Strips the executable (still bigger compared to MSVC, exe is 291 KB)