### PR TITLE
Add arrow key boundary navigation

### DIFF
--- a/src/modules/editor.cpp
+++ b/src/modules/editor.cpp
@@ -233,6 +233,54 @@ LRESULT CALLBACK EditorSubclassProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM l
         }
         break;
     case WM_KEYDOWN:
+        // Handle vertical arrow boundary navigation explicitly.
+        if ((wParam == VK_UP || wParam == VK_DOWN) &&
+            !(GetKeyState(VK_CONTROL) & 0x8000) &&
+            !(GetKeyState(VK_SHIFT) & 0x8000) &&
+            !(GetKeyState(VK_MENU) & 0x8000))
+        {
+            DWORD start = 0, end = 0;
+            SendMessageW(hwnd, EM_GETSEL, reinterpret_cast<WPARAM>(&start), reinterpret_cast<LPARAM>(&end));
+
+            int lineCount = static_cast<int>(SendMessageW(hwnd, EM_GETLINECOUNT, 0, 0));
+            if (lineCount < 1)
+                lineCount = 1;
+
+            if (start != end)
+            {
+                int startLine = static_cast<int>(SendMessageW(hwnd, EM_EXLINEFROMCHAR, 0, start));
+                int endLine = static_cast<int>(SendMessageW(hwnd, EM_EXLINEFROMCHAR, 0, end));
+
+                if (wParam == VK_UP && startLine <= 0)
+                {
+                    SendMessageW(hwnd, EM_SETSEL, start, start);
+                    return 0;
+                }
+
+                if (wParam == VK_DOWN && endLine >= lineCount - 1)
+                {
+                    SendMessageW(hwnd, EM_SETSEL, end, end);
+                    return 0;
+                }
+            }
+            else
+            {
+                int line = static_cast<int>(SendMessageW(hwnd, EM_EXLINEFROMCHAR, 0, start));
+
+                if (wParam == VK_UP && line <= 0)
+                {
+                    SendMessageW(hwnd, EM_SETSEL, 0, 0);
+                    return 0;
+                }
+
+                if (wParam == VK_DOWN && line >= lineCount - 1)
+                {
+                    SendMessageW(hwnd, EM_SETSEL, static_cast<WPARAM>(-1), static_cast<LPARAM>(-1));
+                    return 0;
+                }
+            }
+        }
+
         if (GetKeyState(VK_CONTROL) & 0x8000)
         {
             if (wParam == VK_BACK)


### PR DESCRIPTION
This adds explicit vertical arrow-key behavior at the first and last visual lines of the editor.

When there is no selection:
- Up on the first visual line moves the caret to the start of the document.
- Down on the last visual line moves the caret to the end of the document.

When text is selected at a boundary:
- Up on the first visual line collapses the selection to its start.
- Down on the last visual line collapses the selection to its end.

Other Up/Down behavior is left to RichEdit, and the custom handling is skipped when Ctrl, Shift, or Alt is held.

Tested locally with:
- first and last line navigation
- selections at both boundaries
- middle-line navigation
- wrapped visual lines
- modifier-key combinations