### PR TITLE
Improve Find and Replace dialog keyboard behavior

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -609,6 +609,38 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int nCmdSh
     MSG msg;
     while (GetMessageW(&msg, nullptr, 0, 0))
     {
+        if (g_hwndFindDlg &&
+            msg.message == WM_KEYDOWN &&
+            (GetKeyState(VK_CONTROL) & 0x8000) &&
+            !(GetKeyState(VK_SHIFT) & 0x8000) &&
+            !(GetKeyState(VK_MENU) & 0x8000))
+        {
+            if (msg.wParam == L'F')
+            {
+                SendMessageW(g_hwndMain, WM_COMMAND, MAKEWPARAM(IDM_EDIT_FIND, 0), 0);
+                continue;
+            }
+
+            if (msg.wParam == L'H')
+            {
+                SendMessageW(g_hwndMain, WM_COMMAND, MAKEWPARAM(IDM_EDIT_REPLACE, 0), 0);
+                continue;
+            }
+
+            if (msg.wParam == L'A')
+            {
+                HWND hFocus = GetFocus();
+                HWND hFindEdit = GetDlgItem(g_hwndFindDlg, 1001);
+                HWND hReplaceEdit = GetDlgItem(g_hwndFindDlg, 1002);
+
+                if (hFocus == hFindEdit || hFocus == hReplaceEdit)
+                {
+                    SendMessageW(hFocus, EM_SETSEL, 0, -1);
+                    continue;
+                }
+            }
+        }
+
         if (g_hwndFindDlg && IsDialogMessageW(g_hwndFindDlg, &msg))
             continue;
         if (!TranslateAcceleratorW(g_hwndMain, g_hAccel, &msg))

--- a/src/modules/dialog.cpp
+++ b/src/modules/dialog.cpp
@@ -327,24 +327,24 @@ INT_PTR CALLBACK FindDlgProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
     return DefDlgProcW(hDlg, msg, wParam, lParam);
 }
 
+static std::wstring GetControlText(HWND hwnd)
+{
+    int length = GetWindowTextLengthW(hwnd);
+    std::wstring text(static_cast<size_t>(length) + 1, L'\0');
+    int copied = GetWindowTextW(hwnd, text.data(), length + 1);
+    text.resize(static_cast<size_t>(copied));
+    return text;
+}
+
 static void SaveFindDialogText(HWND hDlg)
 {
-    wchar_t buf[256] = {0};
-
     HWND hFindEdit = GetDlgItem(hDlg, 1001);
     if (hFindEdit)
-    {
-        GetWindowTextW(hFindEdit, buf, 256);
-        g_state.findText = buf;
-    }
+        g_state.findText = GetControlText(hFindEdit);
 
     HWND hReplaceEdit = GetDlgItem(hDlg, 1002);
     if (hReplaceEdit)
-    {
-        buf[0] = L'\0';
-        GetWindowTextW(hReplaceEdit, buf, 256);
-        g_state.replaceText = buf;
-    }
+        g_state.replaceText = GetControlText(hReplaceEdit);
 }
 
 static void FocusFindDialogInput(HWND hDlg)

--- a/src/modules/dialog.cpp
+++ b/src/modules/dialog.cpp
@@ -327,12 +327,45 @@ INT_PTR CALLBACK FindDlgProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
     return DefDlgProcW(hDlg, msg, wParam, lParam);
 }
 
+static void SaveFindDialogText(HWND hDlg)
+{
+    wchar_t buf[256] = {0};
+
+    HWND hFindEdit = GetDlgItem(hDlg, 1001);
+    if (hFindEdit)
+    {
+        GetWindowTextW(hFindEdit, buf, 256);
+        g_state.findText = buf;
+    }
+
+    HWND hReplaceEdit = GetDlgItem(hDlg, 1002);
+    if (hReplaceEdit)
+    {
+        buf[0] = L'\0';
+        GetWindowTextW(hReplaceEdit, buf, 256);
+        g_state.replaceText = buf;
+    }
+}
+
+static void FocusFindDialogInput(HWND hDlg)
+{
+    HWND hFindEdit = GetDlgItem(hDlg, 1001);
+    SetFocus(hFindEdit ? hFindEdit : hDlg);
+}
 void EditFind()
 {
     if (g_hwndFindDlg)
     {
-        SetFocus(g_hwndFindDlg);
-        return;
+        bool isReplaceDialog = GetDlgItem(g_hwndFindDlg, 1002) != nullptr;
+        if (!isReplaceDialog)
+        {
+            FocusFindDialogInput(g_hwndFindDlg);
+            return;
+        }
+
+        SaveFindDialogText(g_hwndFindDlg);
+        DestroyWindow(g_hwndFindDlg);
+        g_hwndFindDlg = nullptr;
     }
     const auto &lang = GetLangStrings();
     g_hwndFindDlg = CreateWindowExW(WS_EX_DLGMODALFRAME, L"#32770", lang.dialogFind.c_str(),
@@ -342,15 +375,16 @@ void EditFind()
     {
         HFONT hFont = reinterpret_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
         CreateWindowExW(0, L"STATIC", lang.dialogFindLabel.c_str(), WS_CHILD | WS_VISIBLE, 10, 12, 45, 16, g_hwndFindDlg, nullptr, nullptr, nullptr);
-        CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", g_state.findText.c_str(), WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL, 60, 10, 230, 20, g_hwndFindDlg, reinterpret_cast<HMENU>(1001), nullptr, nullptr);
-        CreateWindowExW(0, L"BUTTON", lang.dialogFindNext.c_str(), WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON, 300, 10, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(1), nullptr, nullptr);
-        CreateWindowExW(0, L"BUTTON", lang.dialogClose.c_str(), WS_CHILD | WS_VISIBLE, 300, 38, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(2), nullptr, nullptr);
+        CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", g_state.findText.c_str(), WS_CHILD | WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL, 60, 10, 230, 20, g_hwndFindDlg, reinterpret_cast<HMENU>(1001), nullptr, nullptr);
+        CreateWindowExW(0, L"BUTTON", lang.dialogFindNext.c_str(), WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON, 300, 10, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(1), nullptr, nullptr);
+        CreateWindowExW(0, L"BUTTON", lang.dialogClose.c_str(), WS_CHILD | WS_VISIBLE | WS_TABSTOP, 300, 38, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(2), nullptr, nullptr);
         for (HWND h = GetWindow(g_hwndFindDlg, GW_CHILD); h; h = GetWindow(h, GW_HWNDNEXT))
             SendMessageW(h, WM_SETFONT, reinterpret_cast<WPARAM>(hFont), TRUE);
         SetWindowLongPtrW(g_hwndFindDlg, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(FindDlgProc));
         ApplyDialogDarkMode(g_hwndFindDlg);
         InvalidateRect(g_hwndFindDlg, nullptr, FALSE);
         UpdateWindow(g_hwndFindDlg);
+        FocusFindDialogInput(g_hwndFindDlg);
     }
 }
 
@@ -370,8 +404,16 @@ void EditReplace()
 {
     if (g_hwndFindDlg)
     {
-        SetFocus(g_hwndFindDlg);
-        return;
+        bool isReplaceDialog = GetDlgItem(g_hwndFindDlg, 1002) != nullptr;
+        if (isReplaceDialog)
+        {
+            FocusFindDialogInput(g_hwndFindDlg);
+            return;
+        }
+
+        SaveFindDialogText(g_hwndFindDlg);
+        DestroyWindow(g_hwndFindDlg);
+        g_hwndFindDlg = nullptr;
     }
     const auto &lang = GetLangStrings();
     g_hwndFindDlg = CreateWindowExW(WS_EX_DLGMODALFRAME, L"#32770", lang.dialogFindReplace.c_str(),
@@ -381,19 +423,20 @@ void EditReplace()
     {
         HFONT hFont = reinterpret_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
         CreateWindowExW(0, L"STATIC", lang.dialogFindLabel.c_str(), WS_CHILD | WS_VISIBLE, 10, 12, 45, 16, g_hwndFindDlg, nullptr, nullptr, nullptr);
-        CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", g_state.findText.c_str(), WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL, 60, 10, 230, 20, g_hwndFindDlg, reinterpret_cast<HMENU>(1001), nullptr, nullptr);
+        CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", g_state.findText.c_str(), WS_CHILD | WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL, 60, 10, 230, 20, g_hwndFindDlg, reinterpret_cast<HMENU>(1001), nullptr, nullptr);
         CreateWindowExW(0, L"STATIC", lang.dialogReplaceLabel.c_str(), WS_CHILD | WS_VISIBLE, 10, 40, 50, 16, g_hwndFindDlg, nullptr, nullptr, nullptr);
-        CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", g_state.replaceText.c_str(), WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL, 60, 38, 230, 20, g_hwndFindDlg, reinterpret_cast<HMENU>(1002), nullptr, nullptr);
-        CreateWindowExW(0, L"BUTTON", lang.dialogFindNext.c_str(), WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON, 300, 10, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(1), nullptr, nullptr);
-        CreateWindowExW(0, L"BUTTON", lang.dialogReplace.c_str(), WS_CHILD | WS_VISIBLE, 300, 38, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(3), nullptr, nullptr);
-        CreateWindowExW(0, L"BUTTON", lang.dialogReplaceAll.c_str(), WS_CHILD | WS_VISIBLE, 300, 66, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(4), nullptr, nullptr);
-        CreateWindowExW(0, L"BUTTON", lang.dialogClose.c_str(), WS_CHILD | WS_VISIBLE, 300, 94, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(2), nullptr, nullptr);
+        CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", g_state.replaceText.c_str(), WS_CHILD | WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL, 60, 38, 230, 20, g_hwndFindDlg, reinterpret_cast<HMENU>(1002), nullptr, nullptr);
+        CreateWindowExW(0, L"BUTTON", lang.dialogFindNext.c_str(), WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON, 300, 10, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(1), nullptr, nullptr);
+        CreateWindowExW(0, L"BUTTON", lang.dialogReplace.c_str(), WS_CHILD | WS_VISIBLE | WS_TABSTOP, 300, 38, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(3), nullptr, nullptr);
+        CreateWindowExW(0, L"BUTTON", lang.dialogReplaceAll.c_str(), WS_CHILD | WS_VISIBLE | WS_TABSTOP, 300, 66, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(4), nullptr, nullptr);
+        CreateWindowExW(0, L"BUTTON", lang.dialogClose.c_str(), WS_CHILD | WS_VISIBLE | WS_TABSTOP, 300, 94, 100, 22, g_hwndFindDlg, reinterpret_cast<HMENU>(2), nullptr, nullptr);
         for (HWND h = GetWindow(g_hwndFindDlg, GW_CHILD); h; h = GetWindow(h, GW_HWNDNEXT))
             SendMessageW(h, WM_SETFONT, reinterpret_cast<WPARAM>(hFont), TRUE);
         SetWindowLongPtrW(g_hwndFindDlg, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(FindDlgProc));
         ApplyDialogDarkMode(g_hwndFindDlg);
         InvalidateRect(g_hwndFindDlg, nullptr, FALSE);
         UpdateWindow(g_hwndFindDlg);
+        FocusFindDialogInput(g_hwndFindDlg);
     }
 }
 


### PR DESCRIPTION
This improves keyboard interaction for the modeless Find and Replace dialogs.

Changes:
- Focuses the Find field when opening Find or Replace.
- Allows Ctrl+F and Ctrl+H to switch between the Find and Replace dialogs.
- Preserves entered Find and Replace text when switching dialogs.
- Handles Ctrl+A inside the dialog edit fields.
- Adds Tab and Shift+Tab navigation between dialog controls.

The Ctrl+F / Ctrl+H handling is performed before IsDialogMessageW so Ctrl+H is not interpreted as Backspace while the Find field has focus.

Other editor shortcuts continue to use the existing dialog and accelerator handling.

Tested locally with:
- opening Find and Replace from the editor
- switching between Find and Replace with Ctrl+F / Ctrl+H
- preserving entered search text while switching
- Ctrl+A in Find and Replace fields
- Tab and Shift+Tab navigation