### PR TITLE
Fix delayed mouse wheel scrolling

### DIFF
--- a/src/modules/editor.cpp
+++ b/src/modules/editor.cpp
@@ -255,9 +255,10 @@ LRESULT CALLBACK EditorSubclassProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM l
         break;
     case WM_MOUSEWHEEL:
     {
+        int delta = GET_WHEEL_DELTA_WPARAM(wParam);
+
         if (LOWORD(wParam) & MK_SHIFT)
         {
-            int delta = GET_WHEEL_DELTA_WPARAM(wParam);
             UINT scrollLines = 3;
             SystemParametersInfoW(SPI_GETWHEELSCROLLLINES, 0, &scrollLines, 0);
             if (scrollLines == (UINT)WHEEL_PAGESCROLL)
@@ -271,7 +272,31 @@ LRESULT CALLBACK EditorSubclassProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM l
             }
             return 0;
         }
-        break;
+
+        static int wheelDeltaRemainder = 0;
+        wheelDeltaRemainder += delta;
+
+        UINT scrollLines = 3;
+        SystemParametersInfoW(SPI_GETWHEELSCROLLLINES, 0, &scrollLines, 0);
+
+        while (wheelDeltaRemainder >= WHEEL_DELTA || wheelDeltaRemainder <= -WHEEL_DELTA)
+        {
+            bool scrollUp = wheelDeltaRemainder > 0;
+
+            if (scrollLines == (UINT)WHEEL_PAGESCROLL)
+            {
+                SendMessageW(hwnd, WM_VSCROLL, scrollUp ? SB_PAGEUP : SB_PAGEDOWN, 0);
+            }
+            else
+            {
+                for (UINT i = 0; i < scrollLines; ++i)
+                    SendMessageW(hwnd, WM_VSCROLL, scrollUp ? SB_LINEUP : SB_LINEDOWN, 0);
+            }
+
+            wheelDeltaRemainder += scrollUp ? -WHEEL_DELTA : WHEEL_DELTA;
+        }
+
+        return 0;
     }
     case WM_MOUSEHWHEEL:
     {


### PR DESCRIPTION
This fixes delayed vertical mouse-wheel scrolling in the RichEdit control.

Changes:
- Handles vertical `WM_MOUSEWHEEL` input explicitly instead of passing it to RichEdit's default scrolling behavior.
- Accumulates partial wheel deltas for high-resolution mouse-wheel input.
- Respects the Windows `SPI_GETWHEELSCROLLLINES` setting.
- Preserves the existing Shift+mouse-wheel horizontal scrolling behavior.
- Supports the Windows page-scroll setting.

This prevents the editor from continuing to scroll after mouse-wheel input has stopped.

Tested locally with:
- normal vertical mouse-wheel scrolling
- stopping wheel input while the document is moving
- scrolling in both directions
- Shift+mouse-wheel horizontal scrolling